### PR TITLE
Feat: Add skeleton loader to invoice preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-icons": "^3.11.0",
+    "react-loading-skeleton": "^3.1.0",
     "react-mailchimp-subscribe": "^2.1.3",
     "react-router-dom": "^6.2.2",
     "react-scripts": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-icons": "^3.11.0",
-    "react-loading-skeleton": "^3.1.0",
     "react-mailchimp-subscribe": "^2.1.3",
     "react-router-dom": "^6.2.2",
     "react-scripts": "^5.0.0",

--- a/src/components/Organism/Preview/Preview.jsx
+++ b/src/components/Organism/Preview/Preview.jsx
@@ -15,10 +15,9 @@ import {
   Td,
   TableContainer,
   Divider,
+  SkeletonText,
 } from '@chakra-ui/react';
 import { useContext } from 'react';
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
 
 import { InvoiceContext } from '../../../core/InvoiceContext';
 import { checkEmpty } from './check-empty';
@@ -41,8 +40,8 @@ export default function Preview() {
   return (
     isEmpty 
     ? <Stack>
-      <span style={{textAlign: 'center'}}>Please enter details in the Editor tab to preview the invoice.</span>
-      <Skeleton count={5} />
+      <span style={{textAlign: 'center', marginBottom: '10px'}}>Please enter details in the Editor tab to preview the invoice.</span>
+      <SkeletonText mt='4' noOfLines={4} spacing='4' />
     </Stack>
     : <>
       <Stack

--- a/src/components/Organism/Preview/Preview.jsx
+++ b/src/components/Organism/Preview/Preview.jsx
@@ -17,8 +17,11 @@ import {
   Divider,
 } from '@chakra-ui/react';
 import { useContext } from 'react';
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
 
 import { InvoiceContext } from '../../../core/InvoiceContext';
+import { checkEmpty } from './check-empty';
 
 export default function Preview() {
   const { invoice } = useContext(InvoiceContext);
@@ -31,8 +34,17 @@ export default function Preview() {
 
   // find total using tax
   const total = subTotal + (subTotal * tax) / 100;
+
+  // check if invoice details are empty
+  const isEmpty = checkEmpty(invoice);
+
   return (
-    <>
+    isEmpty 
+    ? <Stack>
+      <span style={{textAlign: 'center'}}>Please enter details in the Editor tab to preview the invoice.</span>
+      <Skeleton count={5} />
+    </Stack>
+    : <>
       <Stack
         // bg={useColorModeValue('#fff', '#1A202C')}
         // color={useColorModeValue('gray.800', 'gray.200')}

--- a/src/components/Organism/Preview/SkeletonLoading.jsx
+++ b/src/components/Organism/Preview/SkeletonLoading.jsx
@@ -1,49 +1,42 @@
 import {
-  Stack,
-  Image,
-  Flex,
-  Text,
-  Box,
-  Spacer,
-  Grid,
-  GridItem,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-  TableContainer,
-  Divider,
-} from '@chakra-ui/react';
+    Alert,
+    AlertIcon,
+    Center,
+    Stack,
+    Flex,
+    Text,
+    Box,
+    Spacer,
+    Grid,
+    GridItem,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    TableContainer,
+    Divider,
+    SkeletonText,
+    Skeleton,
+    SkeletonCircle,
+  } from '@chakra-ui/react';
+  
+import React from 'react'
 import { useContext } from 'react';
-
 import { InvoiceContext } from '../../../core/InvoiceContext';
-import { checkEmpty } from './check-empty';
-import SkeletonLoading from './SkeletonLoading';
 
-export default function Preview() {
-  const { invoice } = useContext(InvoiceContext);
-  const invoiceItems = invoice.items;
-  const subTotal = invoiceItems.reduce((acc, item) => {
-    return acc + item.itemQuantity * item.itemPrice;
-  }, 0);
-
-  const tax = invoice.tax;
-
-  // find total using tax
-  const total = subTotal + (subTotal * tax) / 100;
-
-  // check if invoice details are empty
-  const isEmpty = checkEmpty(invoice);
-
+function SkeletonLoading() {
+const { invoice } = useContext(InvoiceContext);
   return (
-    isEmpty 
-    ? <SkeletonLoading />
-    : <>
+    <>
+    <Center>
+        <Alert status='info' style={{width: 'fit-content'}} mb={8}>
+            <AlertIcon />
+            Please enter details in the Editor tab to preview the invoice.
+        </Alert>
+    </Center>
       <Stack
-        // bg={useColorModeValue('#fff', '#1A202C')}
-        // color={useColorModeValue('gray.800', 'gray.200')}
         style={{
           pageBreakAfter:
             invoice.items.length > 3 &&
@@ -56,19 +49,7 @@ export default function Preview() {
         <Stack spacing={10}>
           <Flex>
             <Box>
-              {invoice.yourLogo?.image && (
-                <Image
-                  src={invoice.yourLogo?.image}
-                  alt="company logo"
-                  className="company-logo"
-                  style={{
-                    borderRadius: '10px',
-                    marginBottom: '10px',
-                  }}
-                  w={invoice.yourLogo.imageSize}
-                  h={invoice.yourLogo.imageSize}
-                />
-              )}
+                <SkeletonCircle size='20' />
             </Box>
             <Spacer />
             <Box spacing={3}>
@@ -79,13 +60,7 @@ export default function Preview() {
               >
                 Invoice
               </Text>
-              <Text fontSize="2xl" align="end">
-                {invoice.yourDetails.yourCompany}
-              </Text>
-              <Text align="end">{invoice.yourDetails.yourName}</Text>
-              <Text align="end">{invoice.yourDetails.yourAddress}</Text>
-              <Text align="end">{invoice.yourDetails.yourCity}</Text>
-              <Text align="end">{invoice.yourDetails.yourWebsite}</Text>
+              <SkeletonText mt='4' noOfLines={4} spacing='4' />
             </Box>
           </Flex>
         </Stack>
@@ -101,10 +76,9 @@ export default function Preview() {
               >
                 Bill To :{' '}
               </Text>
-              <Text fontSize="2xl">{invoice.clientDetails.clientName}</Text>
-              <Text>{invoice.clientDetails.clientAddress}</Text>
-              <Text>{invoice.clientDetails.clientCity}</Text>
-              <Text>{invoice.clientDetails.clientWebsite}</Text>
+              <SkeletonText mt='4' noOfLines={4} spacing='4'>
+                <div>contents wrapped</div>
+              </SkeletonText>
             </Box>
 
             <Spacer />
@@ -135,9 +109,9 @@ export default function Preview() {
                   </Text>
                 </GridItem>
                 <GridItem colStart={4} colEnd={6} h="10">
-                  <Text align="end">{invoice.invoiceNumber}</Text>
-                  <Text align="end">{invoice.invoiceDate}</Text>
-                  <Text align="end">{invoice.dueDate}</Text>
+                  <SkeletonText mt='2' noOfLines={3} spacing='4'>
+                    <p>wrap text</p>
+                  </SkeletonText>
                 </GridItem>
               </Grid>
             </Box>
@@ -158,24 +132,21 @@ export default function Preview() {
               </Tr>
             </Thead>
             <Tbody>
-              {invoice.items.map((item, index) => (
-                <Tr
-                  key={index}
-                  bg={
-                    index % 2 !== 0 ? invoice?.backgroundColor + '.50' : 'white'
-                  }
-                >
-                  <Td>{item.itemName}</Td>
-                  <Td>{item.itemQuantity}</Td>
+                <Tr>
                   <Td>
-                    {item.itemCurrency} {item.itemPrice}
+                    <Skeleton height='10px'>Test item</Skeleton>
+                  </Td>
+                  <Td>
+                    <Skeleton height='10px'>Test</Skeleton>
+                  </Td>
+                  <Td>
+                    <Skeleton height='10px'>Test</Skeleton>
                   </Td>
                   <Td isNumeric>
                     {' '}
-                    {item.itemCurrency} {item.itemTotal}
+                    <Skeleton height='10px'>Test</Skeleton>
                   </Td>
                 </Tr>
-              ))}
             </Tbody>
           </Table>
         </TableContainer>
@@ -213,66 +184,28 @@ export default function Preview() {
                 </Text>
               </GridItem>
               <GridItem colStart={4} colEnd={6} h="10">
-                <Text align="end">
-                  {subTotal
-                    ? invoice.items[0].itemCurrency + `${subTotal}`
-                    : '-'}
-                </Text>
-                <Text align="end">{tax ? tax + '%' : 0}</Text>
+                <Skeleton height='10px' mt={2}>Wrap</Skeleton>
+                <Skeleton height='10px' mt={3} mb={2}>Wrap</Skeleton>
                 <Divider
                   borderBottom={`4px solid ${
-                    invoice?.backgroundColor + '.400'
-                  }`}
+                      invoice?.backgroundColor + '.400'
+                    }`}
                   borderColor={invoice?.backgroundColor + '.400'}
                 />
-                <Text align="end">
-                  {total ? invoice.items[0].itemCurrency + `${total}` : '-'}
-                </Text>
+                <Skeleton height='10px' mt={3}>Wrap</Skeleton>
               </GridItem>
             </Grid>
           </Box>
         </Flex>
       </Stack>
-      <Stack mt={8} spacing={3}>
-        {invoice.notes.noteToggle ? null : (
-          <Box>
-            <Text
-              as="h3"
-              fontWeight={'bold'}
-              align="start"
-              color={invoice?.backgroundColor + '.400'}
-            >
-              Notes :
-            </Text>
-            <Text>{invoice.notes.note}</Text>
-          </Box>
-        )}
-      </Stack>{' '}
-      <Stack mt={8} spacing={3}>
-        {invoice.terms.termToggle ? null : (
-          <Box>
-            <Text
-              as="h3"
-              fontWeight={'bold'}
-              align="start"
-              color={invoice?.backgroundColor + '.400'}
-            >
-              Terms & Condition
-            </Text>
-            <Text>{invoice.terms.term}</Text>
-          </Box>
-        )}
-      </Stack>
-      {invoice.digitalSignature.signatureToggle && (
         <Stack
           mt={{
-            base: '20px',
-            md: '20px',
+            base: '60px',
+            md: '60px',
           }}
           spacing={3}
         >
           <Flex justifyContent={'flex-end'}>
-            {invoice.yourDetails.yourCompany && (
               <Box
                 className="stamp is-nope"
                 borderWidth="0.5rem"
@@ -281,40 +214,24 @@ export default function Preview() {
                 color={invoice.digitalSignature.sealColor}
                 borderColor={invoice.digitalSignature.sealColor}
               >
-                {invoice.yourDetails.yourCompany} <br /> RN:
-                {invoice.yourDetails.yourRegistrationNumber}
+                <SkeletonText mt='2' noOfLines={2} spacing='4'>
+                    <p>Sample company name</p>
+                </SkeletonText>
               </Box>
-            )}
           </Flex>
-          {invoice.digitalSignature.signature && (
             <Flex justifyContent={'flex-end'}>
-              <Image
-                className="signature"
-                src={invoice.digitalSignature.signature}
-                alt="signature"
-                width={invoice.digitalSignature.signatureSize}
-                height={invoice.digitalSignature.signatureSize}
-              />
+                <SkeletonCircle size='20' />
             </Flex>
-          )}
           <Box>
-            <Text
-              align="end"
-              fontWeight={'500'}
-              color={invoice?.backgroundColor + '.400'}
-            >
-              {invoice.yourDetails.yourName}
-            </Text>
-            <Text
-              align="end"
-              fontWeight={'500'}
-              color={invoice?.backgroundColor + '.400'}
-            >
-              {invoice.invoiceDate}
-            </Text>
+          <Flex justifyContent={'flex-end'}>
+            <SkeletonText mt='2' noOfLines={2} spacing='4'>
+                    <span>wrap sample text</span>
+            </SkeletonText>
+            </Flex>
           </Box>
         </Stack>
-      )}
     </>
-  );
+  )
 }
+
+export default SkeletonLoading

--- a/src/components/Organism/Preview/check-empty.js
+++ b/src/components/Organism/Preview/check-empty.js
@@ -1,0 +1,31 @@
+function checkEmpty(invoice) {
+    if(invoice.yourLogo instanceof Object && !(invoice.yourLogo.image==='' || invoice.yourLogo.image===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourCompany==='' || invoice.yourDetails.yourCompany===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourCity==='' || invoice.yourDetails.yourCity===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourAddress==='' || invoice.yourDetails.yourAddress===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourName==='' || invoice.yourDetails.yourName===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourEmail==='' || invoice.yourDetails.yourEmail===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourPhone==='' || invoice.yourDetails.yourPhone===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourWebsite==='' || invoice.yourDetails.yourWebsite===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourBank==='' || invoice.yourDetails.yourBank===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourBankAccount==='' || invoice.yourDetails.yourBankAccount===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourBankBranch==='' || invoice.yourDetails.yourBankBranch===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourRegistrationNumber==='' || invoice.yourDetails.yourRegistrationNumber===undefined)) return false;
+    if(invoice.yourDetails instanceof Object && !(invoice.yourDetails.yourAccountNumber==='' || invoice.yourDetails.yourAccountNumber===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientName==='' || invoice.clientDetails.clientName===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientAddress==='' || invoice.clientDetails.clientAddress===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientCity==='' || invoice.clientDetails.clientCity===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientWebsite==='' || invoice.clientDetails.clientWebsite===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientEmail==='' || invoice.clientDetails.clientEmail===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientPhone==='' || invoice.clientDetails.clientPhone===undefined)) return false;
+    if(invoice.clientDetails instanceof Object && !(invoice.clientDetails.clientCompany==='' || invoice.clientDetails.clientCompany===undefined)) return false;
+    if(invoice.items.length > 0) return false;
+    if(invoice.invoiceNumber !== '' && invoice.invoiceNumber!==undefined) return false;
+    if(invoice.invoiceDate !== '' && invoice.invoiceDate!==undefined) return false;
+    if(invoice.dueDate !== '' && invoice.dueDate!==undefined) return false;
+    if(invoice.notes instanceof Object && !(invoice.notes.note === '' || invoice.notes.note ===undefined)) return false;
+    if(invoice.digitalSignature instanceof Object && !(invoice.digitalSignature.signature === '' || invoice.digitalSignature.signature === undefined)) return false;
+    return true;
+}
+  
+export { checkEmpty };


### PR DESCRIPTION
# Description

When there is no data on the editor page, the preview page displays an empty preview. The UX can be improved by displaying a relevant message to the user asking them to add invoice details in the editor tab. Also, a loading skeleton would indicate that the invoice details are pending, and hence invoice is not generated.

Before:
![Screenshot (312)](https://user-images.githubusercontent.com/49197409/194284098-1342494c-0bb7-48a7-9e37-d290b17b2dc3.png)

After:
![image](https://user-images.githubusercontent.com/49197409/194283980-3602fa3d-c08b-49d0-b98a-77c29e8e6c78.png)


Dependencies:
- [react-loading-skeleton npm package](https://www.npmjs.com/package/react-loading-skeleton)

Fixes # (issue)
issue 17

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Functional testing.

## Development & Testing Configuration 


* react version: ^17.0.2


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have read and agree with [Code of Conduct](https://github.com/DunoLabs/invoicetor-landing/blob/main/CODE_OF_CONDUCT.md)

- [X] I have read and agree with [Contributing](https://github.com/dunolabs/invoicetor-landing/blob/main/CONTRIBUTING.md)


